### PR TITLE
fix(mobile): improve mobile navigation sheet touch-away and overlay l…

### DIFF
--- a/src/components/navigation/MobileMoreSheet.js
+++ b/src/components/navigation/MobileMoreSheet.js
@@ -47,12 +47,28 @@ export default function MobileMoreSheet({
       dialog.showModal();
     }
 
+    const handleClickOutside = (e) => {
+      if (e.target === dialog) {
+        onClose?.();
+      }
+    };
+
+    const handleCancel = (e) => {
+      e.preventDefault();
+      onClose?.();
+    };
+
+    dialog.addEventListener('click', handleClickOutside);
+    dialog.addEventListener('cancel', handleCancel);
+
     return () => {
+      dialog.removeEventListener('click', handleClickOutside);
+      dialog.removeEventListener('cancel', handleCancel);
       if (dialog.open) {
         dialog.close();
       }
     };
-  }, [open]);
+  }, [open, onClose]);
 
   return (
     <ModalOverlay

--- a/src/components/shared/HeaderDropdownPanel.js
+++ b/src/components/shared/HeaderDropdownPanel.js
@@ -51,6 +51,9 @@ export default function HeaderDropdownPanel({
   );
 
   if (isMobile && mounted) {
+    const container =
+      (typeof document !== 'undefined' && document.querySelector('dialog[open]')) || document.body;
+
     return createPortal(
       <div data-header-overlay>
         <div
@@ -64,7 +67,7 @@ export default function HeaderDropdownPanel({
           </div>
         </div>
       </div>,
-      document.body
+      container
     );
   }
 

--- a/src/components/shared/HeaderOverlayPortal.js
+++ b/src/components/shared/HeaderOverlayPortal.js
@@ -14,5 +14,8 @@ export default function HeaderOverlayPortal({ children, open }) {
     return null;
   }
 
-  return createPortal(children, document.body);
+  const container =
+    (typeof document !== 'undefined' && document.querySelector('dialog[open]')) || document.body;
+
+  return createPortal(children, container);
 }

--- a/src/components/shared/SystemStatusIndicator.js
+++ b/src/components/shared/SystemStatusIndicator.js
@@ -199,7 +199,7 @@ export default function SystemStatusIndicator({ apiKey, className = '', label, v
               onClick={closePanel}
               aria-hidden
             />
-            <div className="z-overlay-panel fixed inset-0 flex items-end justify-center p-3 sm:items-center sm:p-4 pointer-events-none">
+            <div className="z-overlay-panel fixed inset-0 flex items-center justify-center p-4 pointer-events-none">
               <dialog
                 className="pointer-events-auto w-full max-w-sm max-h-[min(90vh,32rem)] flex flex-col overflow-hidden rounded-xl border border-border bg-surface shadow-2xl dark:border-border-dark dark:bg-surface-alt-dark"
                 style={{ display: 'flex' }}


### PR DESCRIPTION
### Summary of Changes

This PR improves mobile UX for the bottom navigation "More" sheet and utility dropdown overlays:

1. **Touch-Away Dismiss (`MobileMoreSheet.js`):** Added `click` and `cancel` event listeners to the native `<dialog>` element so tapping outside/away from the sheet automatically closes it.
2. **Overlay Layering Fix (`HeaderOverlayPortal.js` & `HeaderDropdownPanel.js`):** Updated mobile portal targets to render inside active open `<dialog>` elements if present. This allows utility overlays (**Notifications**, **System Status**, **Referral**, and **Language Switcher**) to render cleanly in front of the active sheet rather than behind it.
3. **Centered Status Popup (`SystemStatusIndicator.js`):** Centered the mobile system status modal viewport alignment for improved readability on small screens.

### Testing
- Verified with ESLint (`bun run lint`) — 0 errors.
- Verified with Prettier (`bun run format:check`) — passed.
- Verified with i18n validator (`bun run i18n:verify`) — passed.
- No desktop-related files were modified.
